### PR TITLE
Override _open for better error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,13 +38,13 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
   }
 
   [kConnect] (err, cb) {
+    if (err) {
+      return cb(err);
+    }
+    
     // Monitor database state and do not proceed to open if in a non-opening state
     if (!['open', 'opening'].includes(this.status)) {
       return
-    }
-
-    if (err) {
-      return cb(err);
     }
 
     // Attempt to connect to leader as follower

--- a/index.js
+++ b/index.js
@@ -38,6 +38,11 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
   }
 
   [kConnect] (err, cb) {
+    // Monitor database state and do not proceed to open if in a non-opening state
+    if (!['open', 'opening'].includes(this.status)) {
+      return
+    }
+
     if (err) {
       return cb(err);
     }
@@ -60,6 +65,11 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     pipeline(socket, this.createRpcStream({ ref: socket }), socket, () => {
       // Disconnected. Cleanup events
       socket.removeListener('connect', onconnect)
+
+      // Monitor database state and do not proceed to open if in a non-opening state
+      if (!['open', 'opening'].includes(this.status)) {
+        return
+      }
 
       // Attempt to open db as leader
       const db = new ClassicLevel(this[kLocation], this[kOptions])


### PR DESCRIPTION
Pass original callback to kConnect, and kConnect as callback to super._open

This change allows calling the `open` function of the db without providing a callback, in a way that respect the database's `status`, allowing for better error handling.