### PR TITLE
Support getSync for rave-level followers, refactor connection flow

### DIFF
--- a/get-sync-worker.js
+++ b/get-sync-worker.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const { workerData, parentPort } = require('worker_threads')
+const net = require('net')
+const { ManyLevelGuest } = require('many-level')
+
+const port = workerData.port
+
+parentPort.on('message', async function ({ payload, semaphore }) {
+  try {
+    const value = await get(payload.socketPath, payload.key)
+    port.postMessage({ value })
+  } catch (err) {
+    port.postMessage({
+      error: {
+        code: err && err.code,
+        message: err && err.message,
+        stack: err && err.stack
+      }
+    })
+  } finally {
+    Atomics.store(semaphore, 0, 1)
+    Atomics.notify(semaphore, 0, 1)
+  }
+})
+
+async function get (socketPath, key) {
+  const db = new ManyLevelGuest({
+    keyEncoding: 'buffer',
+    valueEncoding: 'buffer',
+    retry: false,
+    _remote: () => net.connect(socketPath)
+  })
+
+  await db.open()
+
+  try {
+    return await db.get(Buffer.from(key), {
+      keyEncoding: 'buffer',
+      valueEncoding: 'buffer'
+    })
+  } finally {
+    await db.close()
+  }
+}

--- a/get-sync.js
+++ b/get-sync.js
@@ -1,0 +1,136 @@
+'use strict'
+
+const ModuleError = require('module-error')
+const { Worker, MessageChannel, receiveMessageOnPort } = require('worker_threads')
+
+const leaders = new Map()
+
+// HERE BE DRAGONS
+//
+// getSync() must be synchronous from abstract-level's perspective, but a follower can only reach the leader through async socket IO.
+// We do that async work in a worker thread, then block this thread with Atomics.wait() until the worker replies.
+// This exists because real LevelDB getSync() blocks too, and some callers may require the sync API surface.
+
+// If you are wondering why God has forsaken us and given us JavaScript: same.
+// This is the pinnacle of cursed code and war crimes. A monstrocity that should never have been born,
+// let alone be considered "useful" for any situation other than inflicting psychological damage.
+exports.createGetSync = function createGetSync (socketPath) {
+  let syncRead
+
+  return function getSync (key, options) {
+    if (options.snapshot !== undefined) {
+      throw new ModuleError('Snapshots are not supported by rave-level getSync() followers', {
+        code: 'LEVEL_NOT_SUPPORTED'
+      })
+    }
+
+    const leader = leaders.get(socketPath)
+
+    if (leader !== undefined) {
+      return leader._getSync(key, options)
+    }
+
+    if (syncRead === undefined) {
+      syncRead = createSyncReadWorker()
+    }
+
+    return syncRead({ socketPath, key })
+  }
+}
+
+exports.registerLeader = function registerLeader (socketPath, db) {
+  leaders.set(socketPath, db)
+
+  return function unregisterLeader () {
+    if (leaders.get(socketPath) === db) {
+      leaders.delete(socketPath)
+    }
+  }
+}
+
+function createSyncReadWorker () {
+  const { port1, port2 } = new MessageChannel()
+  const worker = new Worker(syncReadWorkerCode(), {
+    eval: true,
+    workerData: { port: port2 },
+    transferList: [port2]
+  })
+
+  worker.unref()
+  port1.unref()
+
+  return function syncRead (payload) {
+    const semaphore = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
+
+    worker.postMessage({ payload, semaphore })
+
+    Atomics.wait(semaphore, 0, 0)
+
+    const message = receiveMessageOnPort(port1).message
+
+    if (message.error) {
+      throw remoteError(message.error)
+    }
+
+    return message.value === undefined ? undefined : Buffer.from(message.value)
+  }
+}
+
+function remoteError (error) {
+  const err = new ModuleError(error.message || 'Could not get value', {
+    code: error.code || 'LEVEL_REMOTE_ERROR'
+  })
+
+  if (error.stack) err.stack = error.stack
+  return err
+}
+
+function syncReadWorkerCode () {
+  return `
+    'use strict'
+
+    const { workerData, parentPort } = require('worker_threads')
+    const net = require('net')
+    const { ManyLevelGuest } = require('many-level')
+
+    const port = workerData.port
+
+    parentPort.on('message', async function ({ payload, semaphore }) {
+      try {
+        const value = await get(payload.socketPath, payload.key)
+        port.postMessage({ value })
+      } catch (err) {
+        port.postMessage({
+          error: {
+            code: err && err.code,
+            message: err && err.message,
+            stack: err && err.stack
+          }
+        })
+      } finally {
+        Atomics.store(semaphore, 0, 1)
+        Atomics.notify(semaphore, 0, 1)
+      }
+    })
+
+    async function get (socketPath, key) {
+      const db = new ManyLevelGuest({
+        keyEncoding: 'buffer',
+        valueEncoding: 'buffer',
+        retry: false,
+        _remote: () => net.connect(socketPath)
+      })
+
+      await db.open()
+
+      try {
+        return await db.get(Buffer.from(key), {
+          keyEncoding: 'buffer',
+          valueEncoding: 'buffer'
+        })
+      } finally {
+        await db.close()
+      }
+    }
+  `
+}

--- a/get-sync.js
+++ b/get-sync.js
@@ -2,6 +2,7 @@
 
 const ModuleError = require('module-error')
 const { Worker, MessageChannel, receiveMessageOnPort } = require('worker_threads')
+const path = require('path')
 
 const leaders = new Map()
 
@@ -50,8 +51,7 @@ exports.registerLeader = function registerLeader (socketPath, db) {
 
 function createSyncReadWorker () {
   const { port1, port2 } = new MessageChannel()
-  const worker = new Worker(syncReadWorkerCode(), {
-    eval: true,
+  const worker = new Worker(path.join(__dirname, 'get-sync-worker.js'), {
     workerData: { port: port2 },
     transferList: [port2]
   })
@@ -83,54 +83,4 @@ function remoteError (error) {
 
   if (error.stack) err.stack = error.stack
   return err
-}
-
-function syncReadWorkerCode () {
-  return `
-    'use strict'
-
-    const { workerData, parentPort } = require('worker_threads')
-    const net = require('net')
-    const { ManyLevelGuest } = require('many-level')
-
-    const port = workerData.port
-
-    parentPort.on('message', async function ({ payload, semaphore }) {
-      try {
-        const value = await get(payload.socketPath, payload.key)
-        port.postMessage({ value })
-      } catch (err) {
-        port.postMessage({
-          error: {
-            code: err && err.code,
-            message: err && err.message,
-            stack: err && err.stack
-          }
-        })
-      } finally {
-        Atomics.store(semaphore, 0, 1)
-        Atomics.notify(semaphore, 0, 1)
-      }
-    })
-
-    async function get (socketPath, key) {
-      const db = new ManyLevelGuest({
-        keyEncoding: 'buffer',
-        valueEncoding: 'buffer',
-        retry: false,
-        _remote: () => net.connect(socketPath)
-      })
-
-      await db.open()
-
-      try {
-        return await db.get(Buffer.from(key), {
-          keyEncoding: 'buffer',
-          valueEncoding: 'buffer'
-        })
-      } finally {
-        await db.close()
-      }
-    }
-  `
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,25 @@
-import { AbstractLevel, AbstractDatabaseOptions } from 'abstract-level'
+import {
+  AbstractLevel,
+  AbstractDatabaseOptions,
+  AbstractOpenOptions,
+  AbstractGetOptions,
+  AbstractGetManyOptions,
+  AbstractHasOptions,
+  AbstractHasManyOptions,
+  AbstractPutOptions,
+  AbstractDelOptions,
+  AbstractBatchOperation,
+  AbstractBatchOptions,
+  AbstractChainedBatch,
+  AbstractChainedBatchWriteOptions,
+  AbstractIteratorOptions,
+  AbstractIterator,
+  AbstractKeyIterator,
+  AbstractKeyIteratorOptions,
+  AbstractValueIterator,
+  AbstractValueIteratorOptions,
+  AbstractSnapshot
+} from 'abstract-level'
 
 /**
  * Use a [LevelDB](https://github.com/google/leveldb) database from multiple processes
@@ -8,7 +29,7 @@ import { AbstractLevel, AbstractDatabaseOptions } from 'abstract-level'
  * @template VDefault The default type of values if not overridden on operations.
  */
 export class RaveLevel<KDefault = string, VDefault = string>
-  extends AbstractLevel<Buffer, KDefault, VDefault> {
+  extends AbstractLevel<string | Buffer | Uint8Array, KDefault, VDefault> {
   /**
    * Database constructor.
    *
@@ -20,12 +41,56 @@ export class RaveLevel<KDefault = string, VDefault = string>
     location: string,
     options?: DatabaseOptions<KDefault, VDefault> | undefined
   )
+
+  /**
+   * Whether this instance is the leader process for the database.
+   */
+  isLeader: boolean
+
+  open (): Promise<void>
+  open (options: OpenOptions): Promise<void>
+
+  get (key: KDefault): Promise<VDefault | undefined>
+  get<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): Promise<V | undefined>
+
+  getSync (key: KDefault): VDefault | undefined
+  getSync<K = KDefault, V = VDefault> (key: K, options: GetOptions<K, V>): V | undefined
+
+  getMany (keys: KDefault[]): Promise<Array<VDefault | undefined>>
+  getMany<K = KDefault, V = VDefault> (keys: K[], options: GetManyOptions<K, V>): Promise<Array<V | undefined>>
+
+  has (key: KDefault): Promise<boolean>
+  has<K = KDefault> (key: K, options: HasOptions<K>): Promise<boolean>
+
+  hasMany (keys: KDefault[]): Promise<boolean[]>
+  hasMany<K = KDefault> (keys: K[], options: HasManyOptions<K>): Promise<boolean[]>
+
+  put (key: KDefault, value: VDefault): Promise<void>
+  put<K = KDefault, V = VDefault> (key: K, value: V, options: PutOptions<K, V>): Promise<void>
+
+  del (key: KDefault): Promise<void>
+  del<K = KDefault> (key: K, options: DelOptions<K>): Promise<void>
+
+  batch (operations: Array<BatchOperation<typeof this, KDefault, VDefault>>): Promise<void>
+  batch<K = KDefault, V = VDefault> (operations: Array<BatchOperation<typeof this, K, V>>, options: BatchOptions<K, V>): Promise<void>
+  batch (): ChainedBatch<typeof this, KDefault, VDefault>
+
+  iterator (): Iterator<typeof this, KDefault, VDefault>
+  iterator<K = KDefault, V = VDefault> (options: IteratorOptions<K, V>): Iterator<typeof this, K, V>
+
+  keys (): KeyIterator<typeof this, KDefault>
+  keys<K = KDefault> (options: KeyIteratorOptions<K>): KeyIterator<typeof this, K>
+
+  values (): ValueIterator<typeof this, KDefault, VDefault>
+  values<K = KDefault, V = VDefault> (options: ValueIteratorOptions<K, V>): ValueIterator<typeof this, K, V>
+
+  snapshot (options?: any | undefined): Snapshot
 }
 
 /**
  * Options for the {@link RaveLevel} constructor.
  */
-declare interface DatabaseOptions<K, V> extends
+export interface DatabaseOptions<K, V> extends
   Omit<AbstractDatabaseOptions<K, V>, 'createIfMissing' | 'errorIfExists'> {
   /**
    * If true, operations are retried upon connecting to a new leader. If false,
@@ -35,4 +100,31 @@ declare interface DatabaseOptions<K, V> extends
    * @defaultValue `true`
    */
   retry?: boolean
+
+  /**
+   * Custom socket path used for follower connections.
+   */
+  raveSocketPath?: string | undefined
 }
+
+export type OpenOptions = AbstractOpenOptions
+export type GetOptions<K, V> = AbstractGetOptions<K, V>
+export type GetManyOptions<K, V> = AbstractGetManyOptions<K, V>
+export type HasOptions<K> = AbstractHasOptions<K>
+export type HasManyOptions<K> = AbstractHasManyOptions<K>
+export type PutOptions<K, V> = AbstractPutOptions<K, V>
+export type DelOptions<K> = AbstractDelOptions<K>
+export type BatchOptions<K, V> = AbstractBatchOptions<K, V>
+export type ChainedBatchWriteOptions = AbstractChainedBatchWriteOptions
+
+export type BatchOperation<TDatabase, K, V> = AbstractBatchOperation<TDatabase, K, V>
+export type ChainedBatch<TDatabase, K, V> = AbstractChainedBatch<TDatabase, K, V>
+export type Iterator<TDatabase, K, V> = AbstractIterator<TDatabase, K, V>
+export type KeyIterator<TDatabase, K> = AbstractKeyIterator<TDatabase, K>
+export type ValueIterator<TDatabase, K, V> = AbstractValueIterator<TDatabase, K, V>
+
+export type IteratorOptions<K, V> = AbstractIteratorOptions<K, V>
+export type KeyIteratorOptions<K> = AbstractKeyIteratorOptions<K>
+export type ValueIteratorOptions<K, V> = AbstractValueIteratorOptions<K, V>
+
+export type Snapshot = AbstractSnapshot

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const ModuleError = require('module-error')
 const fs = require('fs').promises
 const net = require('net')
 const path = require('path')
+const { Worker, MessageChannel, receiveMessageOnPort } = require('worker_threads')
 
 /**
  * Maximum time (in milliseconds) to retry connecting before giving up.
@@ -16,6 +17,7 @@ const path = require('path')
  */
 const MAX_CONNECT_RETRY_TIME = 10000 // 10 seconds
 const CONNECT_RETRY_DELAY = 100
+const leaders = new Map()
 
 /**
  * A distributed LevelDB implementation that allows multiple processes to access
@@ -49,15 +51,18 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    */
   constructor (location, options = {}) {
     const { keyEncoding, valueEncoding, retry } = options
+    const resolvedLocation = path.resolve(location)
+    const raveSocketPath = options.raveSocketPath || socketPath(resolvedLocation)
 
     super({
       keyEncoding,
       valueEncoding,
-      retry: retry !== false
+      retry: retry !== false,
+      getSync: createGetSync(raveSocketPath)
     })
 
-    this._location = path.resolve(location)
-    this._socketPath = options.raveSocketPath || socketPath(this._location)
+    this._location = resolvedLocation
+    this._socketPath = raveSocketPath
     this._options = { keyEncoding, valueEncoding }
     this._connectAttemptStartTime = null
 
@@ -201,8 +206,16 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
     const host = new ManyLevelHost(db)
     const { server, close } = this._createServer(host)
+    const closeLeader = async () => {
+      if (leaders.get(this._socketPath) === db) {
+        leaders.delete(this._socketPath)
+      }
 
-    this.attachResource({ close })
+      return close()
+    }
+
+    leaders.set(this._socketPath, db)
+    this.attachResource({ close: closeLeader })
 
     // Bypass socket, so that e.g. this.put() goes directly to db.put()
     // Note: changes order of operations, because we only later flush previous operations (below)
@@ -353,4 +366,114 @@ const socketPath = function (location) {
   } else {
     return path.join(location, 'rave-level.sock')
   }
+}
+
+function createGetSync (socketPath) {
+  let syncRead
+
+  return function getSync (key, options) {
+    if (options.snapshot !== undefined) {
+      throw new ModuleError('Snapshots are not supported by rave-level getSync() followers', {
+        code: 'LEVEL_NOT_SUPPORTED'
+      })
+    }
+
+    const leader = leaders.get(socketPath)
+
+    if (leader !== undefined) {
+      return leader._getSync(key, options)
+    }
+
+    if (syncRead === undefined) {
+      syncRead = createSyncReadWorker()
+    }
+
+    return syncRead({ socketPath, key })
+  }
+}
+
+function createSyncReadWorker () {
+  const { port1, port2 } = new MessageChannel()
+  const worker = new Worker(syncReadWorkerCode(), {
+    eval: true,
+    workerData: { port: port2 },
+    transferList: [port2]
+  })
+
+  worker.unref()
+  port1.unref()
+
+  return function syncRead (payload) {
+    const semaphore = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
+
+    worker.postMessage({ payload, semaphore })
+    Atomics.wait(semaphore, 0, 0)
+
+    const message = receiveMessageOnPort(port1).message
+
+    if (message.error) {
+      throw remoteError(message.error)
+    }
+
+    return message.value === undefined ? undefined : Buffer.from(message.value)
+  }
+}
+
+function remoteError (error) {
+  const err = new ModuleError(error.message || 'Could not get value', {
+    code: error.code || 'LEVEL_REMOTE_ERROR'
+  })
+
+  if (error.stack) err.stack = error.stack
+  return err
+}
+
+function syncReadWorkerCode () {
+  return `
+    'use strict'
+
+    const { workerData, parentPort } = require('worker_threads')
+    const net = require('net')
+    const { ManyLevelGuest } = require('many-level')
+
+    const port = workerData.port
+
+    parentPort.on('message', async function ({ payload, semaphore }) {
+      try {
+        const value = await get(payload.socketPath, payload.key)
+        port.postMessage({ value })
+      } catch (err) {
+        port.postMessage({
+          error: {
+            code: err && err.code,
+            message: err && err.message,
+            stack: err && err.stack
+          }
+        })
+      } finally {
+        Atomics.store(semaphore, 0, 1)
+        Atomics.notify(semaphore, 0, 1)
+      }
+    })
+
+    async function get (socketPath, key) {
+      const db = new ManyLevelGuest({
+        keyEncoding: 'buffer',
+        valueEncoding: 'buffer',
+        retry: false,
+        _remote: () => net.connect(socketPath)
+      })
+
+      await db.open()
+
+      try {
+        return await db.get(Buffer.from(key), {
+          keyEncoding: 'buffer',
+          valueEncoding: 'buffer'
+        })
+      } finally {
+        await db.close()
+      }
+    }
+  `
 }

--- a/index.js
+++ b/index.js
@@ -10,46 +10,12 @@ const net = require('net')
 const path = require('path')
 
 /**
- * Symbol for storing the database location path.
- * @private
- * @type {symbol}
- */
-const kLocation = Symbol('location')
-
-/**
- * Symbol for storing the Unix socket path or Windows named pipe path.
- * @private
- * @type {symbol}
- */
-const kSocketPath = Symbol('socketPath')
-
-/**
- * Symbol for storing database options like encoding settings.
- * @private
- * @type {symbol}
- */
-const kOptions = Symbol('options')
-
-/**
- * Symbol for the internal connect method.
- * @private
- * @type {symbol}
- */
-const kConnect = Symbol('connect')
-
-/**
- * Symbol for the internal destroy method.
- * @private
- * @type {symbol}
- */
-const kDestroy = Symbol('destroy')
-
-/**
  * Maximum time (in milliseconds) to retry connecting before giving up.
  * @constant {number}
  * @default
  */
 const MAX_CONNECT_RETRY_TIME = 10000 // 10 seconds
+const CONNECT_RETRY_DELAY = 100
 
 /**
  * A distributed LevelDB implementation that allows multiple processes to access
@@ -90,18 +56,10 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
       retry: retry !== false
     })
 
-    this[kLocation] = path.resolve(location)
-    this[kSocketPath] = options.raveSocketPath || socketPath(this[kLocation])
-    this[kOptions] = { keyEncoding, valueEncoding }
-    this[kConnect] = this[kConnect].bind(this)
-    this[kDestroy] = this[kDestroy].bind(this)
-
-    /**
-     * Timestamp when the current connection attempt started.
-     * Used to track retry timeouts.
-     * @type {number|null}
-     */
-    this.connectAttemptStartTime = null
+    this._location = path.resolve(location)
+    this._socketPath = options.raveSocketPath || socketPath(this._location)
+    this._options = { keyEncoding, valueEncoding }
+    this._connectAttemptStartTime = null
 
     /**
      * Whether this instance is the leader (has the database lock).
@@ -121,10 +79,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    */
   async _open (options) {
     await super._open(options)
-    return new Promise((resolve, reject) => {
-      // Pass resolve & reject to kConnect so that it can let _open finish when needed
-      this[kConnect](resolve, reject).then(resolve)
-    })
+    await this._connect()
   }
 
   /**
@@ -133,66 +88,89 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    * process that is still starting up.
    *
    * @private
-   * @param {Function} [resolve] - Promise resolve function from _open
-   * @param {Function} [reject] - Promise reject function from _open
    * @returns {Promise<void>}
    */
-  async [kConnect] (resolve, reject) {
-    if (!this.connectAttemptStartTime) this.connectAttemptStartTime = Date.now()
+  async _connect () {
+    if (!this._connectAttemptStartTime) this._connectAttemptStartTime = Date.now()
 
-    // Monitor database state and do not proceed to open if in a non-opening state
-    if (!['open', 'opening'].includes(this.status)) {
-      return
+    while (this._canConnect()) {
+      if (await this._connectToLeader()) return
+
+      const { db, retry } = await this._tryOpenLeaderDatabase()
+
+      if (db) {
+        await this._becomeLeader(db)
+        return
+      }
+
+      if (!retry) return
+
+      await new Promise(resolve => setTimeout(resolve, CONNECT_RETRY_DELAY))
     }
+  }
 
-    // Attempt to connect to leader as follower
-    const socket = net.connect(this[kSocketPath])
+  _canConnect () {
+    return this.status === 'open' || this.status === 'opening'
+  }
 
-    // Track whether we succeeded to connect
+  async _connectToLeader () {
+    const socket = net.connect(this._socketPath)
+    const onerror = () => {}
+    socket.on('error', onerror)
+
+    const stream = this.createRpcStream({ ref: socket })
     let connected = false
+    let settled = false
+    let settle
 
-    /**
-     * Callback fired when socket successfully connects to a leader.
-     * Resolves the _open promise to allow the database to finish opening.
-     *
-     * @private
-     * @function onconnect
-     * @returns {void}
-     */
-    const onconnect = () => {
-      connected = true
-      // If we manage to connect to an existing host, [kConnect] will be waiting in the pipeline
-      // call below. We need to resolve the promise here, so that _open can finish.
-      if (resolve) resolve()
-      resolve = reject = null
-    }
-    const onclose = () => {
-      connected = false
-      this.connectAttemptStartTime = null
-      // Disconnected. Cleanup events.
+    const connectedPromise = new Promise(resolve => {
+      settle = (value) => {
+        if (settled) return
+        settled = true
+        resolve(value)
+      }
+    })
+
+    const cleanup = () => {
       socket.removeListener('connect', onconnect)
       socket.removeListener('close', onclose)
+      socket.removeListener('error', onerror)
     }
+
+    const onconnect = () => {
+      connected = true
+      this._connectAttemptStartTime = null
+      settle(true)
+    }
+
+    const onclose = () => {
+      if (!connected) settle(false)
+    }
+
     socket.once('connect', onconnect)
     socket.once('close', onclose)
 
-    // Pass socket as the ref option so we don't hang the event loop.
-    await pipeline(socket, this.createRpcStream({ ref: socket }), socket).catch(() => null)
-    // Disconnected. Cleanup events.
-    socket.removeListener('connect', onconnect)
-    socket.removeListener('close', onclose)
+    pipeline(socket, stream, socket).catch(() => null).then(() => {
+      cleanup()
+      if (!connected) settle(false)
+      if (connected && this._canConnect()) {
+        setImmediate(() => {
+          if (this._canConnect()) {
+            this._connect().catch(err => this._destroy(err))
+          }
+        })
+      }
+    })
 
-    // Monitor database state and do not proceed to open if in a non-opening state
-    if (!['open', 'opening'].includes(this.status)) {
-      return
-    }
+    return connectedPromise
+  }
 
-    // We are still trying to open the db the first time and there is no leader yet to connect to.
-    // Attempt to open db as leader
-    const db = new ClassicLevel(this[kLocation], this[kOptions])
+  async _tryOpenLeaderDatabase () {
+    const db = new ClassicLevel(this._location, this._options)
 
     // When guest db is closed, close db
     this.attachResource(db)
+
     try {
       await db.open()
     } catch (err) {
@@ -201,42 +179,56 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
       // If already locked, another process became the leader
       if (err.cause && err.cause.code === 'LEVEL_LOCKED') {
-        // If we've been retrying for too long, abort.
-        if (this.connectAttemptStartTime && (Date.now() - this.connectAttemptStartTime > MAX_CONNECT_RETRY_TIME)) {
-          return this[kDestroy](err)
+        if (this._connectAttemptStartTime && (Date.now() - this._connectAttemptStartTime > MAX_CONNECT_RETRY_TIME)) {
+          this._destroy(err)
+          return { retry: false }
         }
-        if (connected) {
-          return this[kConnect](resolve, reject)
-        } else {
-          // Wait for a short delay
-          await new Promise((resolve) => setTimeout(resolve, 100))
-          // Call connect again
-          return this[kConnect](resolve, reject)
-        }
-      } else {
-        return this[kDestroy](err)
+
+        return { retry: true }
       }
+
+      this._destroy(err)
+      return { retry: false }
     }
 
-    if (!['open', 'opening'].includes(this.status)) {
-      return
-    }
+    return { db, retry: false }
+  }
 
-    // We're the leader now
+  async _becomeLeader (db) {
+    if (!this._canConnect()) return
+
+    if (!await this._removeStaleSocket()) return
+
+    const host = new ManyLevelHost(db)
+    const { server, close } = this._createServer(host)
+
+    this.attachResource({ close })
+
+    // Bypass socket, so that e.g. this.put() goes directly to db.put()
+    // Note: changes order of operations, because we only later flush previous operations (below)
+    this.forward(db)
+
+    server.listen(this._socketPath, () => this._onLeaderListening(server))
+  }
+
+  async _removeStaleSocket () {
     try {
-      await fs.unlink(this[kSocketPath])
+      await fs.unlink(this._socketPath)
     } catch (err) {
-      if (!['open', 'opening'].includes(this.status)) {
-        return
+      if (!this._canConnect()) {
+        return false
       }
 
       if (err && err.code !== 'ENOENT') {
-        return this[kDestroy](err)
+        this._destroy(err)
+        return false
       }
     }
 
-    // Create host to expose db
-    const host = new ManyLevelHost(db)
+    return true
+  }
+
+  _createServer (host) {
     const sockets = new Set()
 
     /**
@@ -254,7 +246,8 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
       sockets.delete(sock)
     })
 
-    server.on('error', this[kDestroy])
+    const onerror = err => this._destroy(err)
+    server.on('error', onerror)
 
     /**
      * Cleanup function that closes all follower connections and shuts down
@@ -269,66 +262,56 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
         sock.destroy()
       }
 
-      server.removeListener('error', this[kDestroy])
+      server.removeListener('error', onerror)
       return server.close()
     }
 
-    // When guest db is closed, close server
-    this.attachResource({ close })
+    return { server, close }
+  }
 
-    // Bypass socket, so that e.g. this.put() goes directly to db.put()
-    // Note: changes order of operations, because we only later flush previous operations (below)
-    this.forward(db)
+  async _onLeaderListening (server) {
+    server.unref()
 
-    server.listen(this[kSocketPath], async () => {
-      server.unref()
+    if (this.status !== 'open') {
+      return
+    }
 
-      if (this.status !== 'open') {
-        return
-      }
+    this.isLeader = true
 
-      this.isLeader = true
+    /**
+     * Leader event.
+     * Fired when this instance successfully becomes the database leader.
+     *
+     * @event RaveLevel#leader
+     */
+    this.emit('leader')
 
-      /**
-       * Leader event.
-       * Fired when this instance successfully becomes the database leader.
-       *
-       * @event RaveLevel#leader
-       */
-      this.emit('leader')
+    if (this.status !== 'open' || this.isFlushed()) {
+      return
+    }
 
-      if (this.status !== 'open' || this.isFlushed()) {
-        return
-      }
+    await this._flushPendingRequests()
+  }
 
-      // Connect to ourselves to flush pending requests
-      const sock = net.connect(this[kSocketPath])
+  async _flushPendingRequests () {
+    const sock = net.connect(this._socketPath)
 
-      /**
-       * Callback that destroys the flush socket when all pending
-       * operations have been processed.
-       *
-       * @private
-       * @function onflush
-       * @returns {void}
-       */
-      const onflush = () => { sock.destroy() }
+    const onflush = () => { sock.destroy() }
 
-      this.once('flush', onflush)
+    this.once('flush', onflush)
 
-      let cause
-      try {
-        await pipeline(sock, this.createRpcStream(), sock)
-      } catch (err) {
-        cause = err
-      }
-      this.removeListener('flush', onflush)
+    let cause
+    try {
+      await pipeline(sock, this.createRpcStream(), sock)
+    } catch (err) {
+      cause = err
+    }
+    this.removeListener('flush', onflush)
 
-      // Socket should only close because of a this.close()
-      if (!this.isFlushed() && this.status === 'open') {
-        this[kDestroy](new ModuleError('Did not flush', { cause }))
-      }
-    })
+    // Socket should only close because of a this.close()
+    if (!this.isFlushed() && this.status === 'open') {
+      this._destroy(new ModuleError('Did not flush', { cause }))
+    }
   }
 
   /**
@@ -340,7 +323,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    * @returns {void}
    * @fires RaveLevel#error
    */
-  [kDestroy] (err) {
+  _destroy (err) {
     if (this.status === 'open') {
       /**
        * Error event.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const ModuleError = require('module-error')
 const fs = require('fs').promises
 const net = require('net')
 const path = require('path')
-const { Worker, MessageChannel, receiveMessageOnPort } = require('worker_threads')
+const { createGetSync, registerLeader } = require('./get-sync')
 
 /**
  * Maximum time (in milliseconds) to retry connecting before giving up.
@@ -17,7 +17,6 @@ const { Worker, MessageChannel, receiveMessageOnPort } = require('worker_threads
  */
 const MAX_CONNECT_RETRY_TIME = 10000 // 10 seconds
 const CONNECT_RETRY_DELAY = 100
-const leaders = new Map()
 
 /**
  * A distributed LevelDB implementation that allows multiple processes to access
@@ -206,15 +205,12 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
     const host = new ManyLevelHost(db)
     const { server, close } = this._createServer(host)
+    const unregisterLeader = registerLeader(this._socketPath, db)
     const closeLeader = async () => {
-      if (leaders.get(this._socketPath) === db) {
-        leaders.delete(this._socketPath)
-      }
-
+      unregisterLeader()
       return close()
     }
 
-    leaders.set(this._socketPath, db)
     this.attachResource({ close: closeLeader })
 
     // Bypass socket, so that e.g. this.put() goes directly to db.put()
@@ -366,114 +362,4 @@ const socketPath = function (location) {
   } else {
     return path.join(location, 'rave-level.sock')
   }
-}
-
-function createGetSync (socketPath) {
-  let syncRead
-
-  return function getSync (key, options) {
-    if (options.snapshot !== undefined) {
-      throw new ModuleError('Snapshots are not supported by rave-level getSync() followers', {
-        code: 'LEVEL_NOT_SUPPORTED'
-      })
-    }
-
-    const leader = leaders.get(socketPath)
-
-    if (leader !== undefined) {
-      return leader._getSync(key, options)
-    }
-
-    if (syncRead === undefined) {
-      syncRead = createSyncReadWorker()
-    }
-
-    return syncRead({ socketPath, key })
-  }
-}
-
-function createSyncReadWorker () {
-  const { port1, port2 } = new MessageChannel()
-  const worker = new Worker(syncReadWorkerCode(), {
-    eval: true,
-    workerData: { port: port2 },
-    transferList: [port2]
-  })
-
-  worker.unref()
-  port1.unref()
-
-  return function syncRead (payload) {
-    const semaphore = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT))
-
-    worker.postMessage({ payload, semaphore })
-    Atomics.wait(semaphore, 0, 0)
-
-    const message = receiveMessageOnPort(port1).message
-
-    if (message.error) {
-      throw remoteError(message.error)
-    }
-
-    return message.value === undefined ? undefined : Buffer.from(message.value)
-  }
-}
-
-function remoteError (error) {
-  const err = new ModuleError(error.message || 'Could not get value', {
-    code: error.code || 'LEVEL_REMOTE_ERROR'
-  })
-
-  if (error.stack) err.stack = error.stack
-  return err
-}
-
-function syncReadWorkerCode () {
-  return `
-    'use strict'
-
-    const { workerData, parentPort } = require('worker_threads')
-    const net = require('net')
-    const { ManyLevelGuest } = require('many-level')
-
-    const port = workerData.port
-
-    parentPort.on('message', async function ({ payload, semaphore }) {
-      try {
-        const value = await get(payload.socketPath, payload.key)
-        port.postMessage({ value })
-      } catch (err) {
-        port.postMessage({
-          error: {
-            code: err && err.code,
-            message: err && err.message,
-            stack: err && err.stack
-          }
-        })
-      } finally {
-        Atomics.store(semaphore, 0, 1)
-        Atomics.notify(semaphore, 0, 1)
-      }
-    })
-
-    async function get (socketPath, key) {
-      const db = new ManyLevelGuest({
-        keyEncoding: 'buffer',
-        valueEncoding: 'buffer',
-        retry: false,
-        _remote: () => net.connect(socketPath)
-      })
-
-      await db.open()
-
-      try {
-        return await db.get(Buffer.from(key), {
-          keyEncoding: 'buffer',
-          valueEncoding: 'buffer'
-        })
-      } finally {
-        await db.close()
-      }
-    }
-  `
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,104 @@ const path = require('path')
 const { createGetSync, registerLeader } = require('./get-sync')
 
 /**
+ * Symbol for storing the database location path.
+ * @private
+ * @type {symbol}
+ */
+const kLocation = Symbol('location')
+
+/**
+ * Symbol for storing the Unix socket path or Windows named pipe path.
+ * @private
+ * @type {symbol}
+ */
+const kSocketPath = Symbol('socketPath')
+
+/**
+ * Symbol for storing database options like encoding settings.
+ * @private
+ * @type {symbol}
+ */
+const kOptions = Symbol('options')
+
+/**
+ * Symbol for storing when the current connection attempt started.
+ * @private
+ * @type {symbol}
+ */
+const kConnectAttemptStartTime = Symbol('connectAttemptStartTime')
+
+/**
+ * Symbol for the internal connect method.
+ * @private
+ * @type {symbol}
+ */
+const kConnect = Symbol('connect')
+
+/**
+ * Symbol for the internal connection state check.
+ * @private
+ * @type {symbol}
+ */
+const kCanConnect = Symbol('canConnect')
+
+/**
+ * Symbol for connecting this instance to the current leader.
+ * @private
+ * @type {symbol}
+ */
+const kConnectToLeader = Symbol('connectToLeader')
+
+/**
+ * Symbol for attempting to open the underlying LevelDB instance as leader.
+ * @private
+ * @type {symbol}
+ */
+const kTryOpenLeaderDatabase = Symbol('tryOpenLeaderDatabase')
+
+/**
+ * Symbol for turning this instance into the active leader.
+ * @private
+ * @type {symbol}
+ */
+const kBecomeLeader = Symbol('becomeLeader')
+
+/**
+ * Symbol for removing a stale socket before listening as leader.
+ * @private
+ * @type {symbol}
+ */
+const kRemoveStaleSocket = Symbol('removeStaleSocket')
+
+/**
+ * Symbol for creating the follower RPC server.
+ * @private
+ * @type {symbol}
+ */
+const kCreateServer = Symbol('createServer')
+
+/**
+ * Symbol for finalizing leader startup once the socket is listening.
+ * @private
+ * @type {symbol}
+ */
+const kOnLeaderListening = Symbol('onLeaderListening')
+
+/**
+ * Symbol for flushing pending guest requests after becoming leader.
+ * @private
+ * @type {symbol}
+ */
+const kFlushPendingRequests = Symbol('flushPendingRequests')
+
+/**
+ * Symbol for the internal destroy method.
+ * @private
+ * @type {symbol}
+ */
+const kDestroy = Symbol('destroy')
+
+/**
  * Maximum time (in milliseconds) to retry connecting before giving up.
  * @constant {number}
  * @default
@@ -60,10 +158,10 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
       getSync: createGetSync(raveSocketPath)
     })
 
-    this._location = resolvedLocation
-    this._socketPath = raveSocketPath
-    this._options = { keyEncoding, valueEncoding }
-    this._connectAttemptStartTime = null
+    this[kLocation] = resolvedLocation
+    this[kSocketPath] = raveSocketPath
+    this[kOptions] = { keyEncoding, valueEncoding }
+    this[kConnectAttemptStartTime] = null
 
     /**
      * Whether this instance is the leader (has the database lock).
@@ -83,27 +181,29 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    */
   async _open (options) {
     await super._open(options)
-    await this._connect()
+    await this[kConnect]()
   }
 
   /**
    * Attempts to connect to an existing leader or become the leader.
    * This method will retry multiple times if the database is locked by another
-   * process that is still starting up.
+   * process that is still starting up. It returns once this instance either
+   * connects to a leader or becomes the leader; callers must invoke it again
+   * when a leader connection closes to preserve failover.
    *
    * @private
    * @returns {Promise<void>}
    */
-  async _connect () {
-    if (!this._connectAttemptStartTime) this._connectAttemptStartTime = Date.now()
+  async [kConnect] () {
+    if (!this[kConnectAttemptStartTime]) this[kConnectAttemptStartTime] = Date.now()
 
-    while (this._canConnect()) {
-      if (await this._connectToLeader()) return
+    while (this[kCanConnect]()) {
+      if (await this[kConnectToLeader]()) return
 
-      const { db, retry } = await this._tryOpenLeaderDatabase()
+      const { db, retry } = await this[kTryOpenLeaderDatabase]()
 
       if (db) {
-        await this._becomeLeader(db)
+        await this[kBecomeLeader](db)
         return
       }
 
@@ -113,12 +213,24 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     }
   }
 
-  _canConnect () {
+  /**
+   * Whether this instance is still allowed to connect or become leader.
+   *
+   * @private
+   * @returns {boolean}
+   */
+  [kCanConnect] () {
     return this.status === 'open' || this.status === 'opening'
   }
 
-  async _connectToLeader () {
-    const socket = net.connect(this._socketPath)
+  /**
+   * Attempts to connect this instance to the current leader process.
+   *
+   * @private
+   * @returns {Promise<boolean>} True if a leader connection was established.
+   */
+  async [kConnectToLeader] () {
+    const socket = net.connect(this[kSocketPath])
     const onerror = () => {}
     socket.on('error', onerror)
 
@@ -143,7 +255,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
     const onconnect = () => {
       connected = true
-      this._connectAttemptStartTime = null
+      this[kConnectAttemptStartTime] = null
       settle(true)
     }
 
@@ -157,10 +269,12 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     pipeline(socket, stream, socket).catch(() => null).then(() => {
       cleanup()
       if (!connected) settle(false)
-      if (connected && this._canConnect()) {
+      if (connected && this[kCanConnect]()) {
+        // The previous leader closed. Reconnect so this instance either follows
+        // the new leader or becomes it.
         setImmediate(() => {
-          if (this._canConnect()) {
-            this._connect().catch(err => this._destroy(err))
+          if (this[kCanConnect]()) {
+            this[kConnect]().catch(err => this[kDestroy](err))
           }
         })
       }
@@ -169,8 +283,14 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     return connectedPromise
   }
 
-  async _tryOpenLeaderDatabase () {
-    const db = new ClassicLevel(this._location, this._options)
+  /**
+   * Attempts to open the underlying LevelDB database as the leader.
+   *
+   * @private
+   * @returns {Promise<{db?: ClassicLevel, retry: boolean}>}
+   */
+  async [kTryOpenLeaderDatabase] () {
+    const db = new ClassicLevel(this[kLocation], this[kOptions])
 
     // When guest db is closed, close db
     this.attachResource(db)
@@ -183,29 +303,36 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
       // If already locked, another process became the leader
       if (err.cause && err.cause.code === 'LEVEL_LOCKED') {
-        if (this._connectAttemptStartTime && (Date.now() - this._connectAttemptStartTime > MAX_CONNECT_RETRY_TIME)) {
-          this._destroy(err)
+        if (this[kConnectAttemptStartTime] && (Date.now() - this[kConnectAttemptStartTime] > MAX_CONNECT_RETRY_TIME)) {
+          this[kDestroy](err)
           return { retry: false }
         }
 
         return { retry: true }
       }
 
-      this._destroy(err)
+      this[kDestroy](err)
       return { retry: false }
     }
 
     return { db, retry: false }
   }
 
-  async _becomeLeader (db) {
-    if (!this._canConnect()) return
+  /**
+   * Starts the RPC host and forwards local operations to the leader database.
+   *
+   * @private
+   * @param {ClassicLevel} db - The open database for this leader.
+   * @returns {Promise<void>}
+   */
+  async [kBecomeLeader] (db) {
+    if (!this[kCanConnect]()) return
 
-    if (!await this._removeStaleSocket()) return
+    if (!await this[kRemoveStaleSocket]()) return
 
     const host = new ManyLevelHost(db)
-    const { server, close } = this._createServer(host)
-    const unregisterLeader = registerLeader(this._socketPath, db)
+    const { server, close } = this[kCreateServer](host)
+    const unregisterLeader = registerLeader(this[kSocketPath], db)
     const closeLeader = async () => {
       unregisterLeader()
       return close()
@@ -217,19 +344,25 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     // Note: changes order of operations, because we only later flush previous operations (below)
     this.forward(db)
 
-    server.listen(this._socketPath, () => this._onLeaderListening(server))
+    server.listen(this[kSocketPath], () => this[kOnLeaderListening](server))
   }
 
-  async _removeStaleSocket () {
+  /**
+   * Removes the socket left behind by a crashed or exited leader.
+   *
+   * @private
+   * @returns {Promise<boolean>} True if startup can continue.
+   */
+  async [kRemoveStaleSocket] () {
     try {
-      await fs.unlink(this._socketPath)
+      await fs.unlink(this[kSocketPath])
     } catch (err) {
-      if (!this._canConnect()) {
+      if (!this[kCanConnect]()) {
         return false
       }
 
       if (err && err.code !== 'ENOENT') {
-        this._destroy(err)
+        this[kDestroy](err)
         return false
       }
     }
@@ -237,7 +370,14 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     return true
   }
 
-  _createServer (host) {
+  /**
+   * Creates the RPC server that followers connect to.
+   *
+   * @private
+   * @param {ManyLevelHost} host - Host wrapping the leader database.
+   * @returns {{server: net.Server, close: Function}}
+   */
+  [kCreateServer] (host) {
     const sockets = new Set()
 
     /**
@@ -255,7 +395,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
       sockets.delete(sock)
     })
 
-    const onerror = err => this._destroy(err)
+    const onerror = err => this[kDestroy](err)
     server.on('error', onerror)
 
     /**
@@ -278,7 +418,14 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
     return { server, close }
   }
 
-  async _onLeaderListening (server) {
+  /**
+   * Marks this instance as leader and flushes pending guest requests.
+   *
+   * @private
+   * @param {net.Server} server - The listening follower RPC server.
+   * @returns {Promise<void>}
+   */
+  async [kOnLeaderListening] (server) {
     server.unref()
 
     if (this.status !== 'open') {
@@ -299,11 +446,17 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
       return
     }
 
-    await this._flushPendingRequests()
+    await this[kFlushPendingRequests]()
   }
 
-  async _flushPendingRequests () {
-    const sock = net.connect(this._socketPath)
+  /**
+   * Flushes pending guest requests through the newly-created local leader.
+   *
+   * @private
+   * @returns {Promise<void>}
+   */
+  async [kFlushPendingRequests] () {
+    const sock = net.connect(this[kSocketPath])
 
     const onflush = () => { sock.destroy() }
 
@@ -319,7 +472,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
 
     // Socket should only close because of a this.close()
     if (!this.isFlushed() && this.status === 'open') {
-      this._destroy(new ModuleError('Did not flush', { cause }))
+      this[kDestroy](new ModuleError('Did not flush', { cause }))
     }
   }
 
@@ -332,7 +485,7 @@ exports.RaveLevel = class RaveLevel extends ManyLevelGuest {
    * @returns {void}
    * @fires RaveLevel#error
    */
-  _destroy (err) {
+  [kDestroy] (err) {
     if (this.status === 'open') {
       /**
        * Error event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "classic-level": "^3.0.0",
-        "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#7adbb795f0114ca3933fe24bee2145ea3b0aeb51",
+        "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#4ea68e59bfb40385c09fd641c1192f7fdce58285",
         "module-error": "^1.0.2",
         "readable-stream": "^4.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "classic-level": "^2.0.0",
+        "classic-level": "^3.0.0",
         "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#7adbb795f0114ca3933fe24bee2145ea3b0aeb51",
         "module-error": "^1.0.2",
         "readable-stream": "^4.0.0"
@@ -1259,20 +1259,20 @@
       }
     },
     "node_modules/abstract-level": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-2.0.2.tgz",
-      "integrity": "sha512-pPJixmXk/kTKLB2sSue7o4Uj6TlLD2XfaP2gWZomHVCC6cuUGX/VslQqKG1yZHfXwBb/3lS6oSTMPGzh1P1iig==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-3.1.1.tgz",
+      "integrity": "sha512-CW2gKbJFTuX1feMvOrvsVMmijAOgI9kg2Ie9Dq3gOcMt/dVVoVmqNlLcEUCT13NxHFMEajcUcVBIplbyDroDiw==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "is-buffer": "^2.0.5",
-        "level-supports": "^6.0.0",
+        "level-supports": "^6.2.0",
         "level-transcoder": "^1.0.1",
         "maybe-combine-errors": "^1.0.0",
         "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/acorn": {
@@ -2089,13 +2089,13 @@
       }
     },
     "node_modules/classic-level": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-2.0.0.tgz",
-      "integrity": "sha512-ftiMvKgCQK+OppXcvMieDoYlYLYWhScK6yZRFBrrlHQRbm4k6Gr+yDgu/wt3V0k1/jtNbuiXAsRmuAFcD0Tx5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-3.0.0.tgz",
+      "integrity": "sha512-yGy8j8LjPbN0Bh3+ygmyYvrmskVita92pD/zCoalfcC9XxZj6iDtZTAnz+ot7GG8p9KLTG+MZ84tSA4AhkgVZQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "abstract-level": "^2.0.0",
+        "abstract-level": "^3.1.0",
         "module-error": "^1.0.1",
         "napi-macros": "^2.2.2",
         "node-gyp-build": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "classic-level": "^3.0.0",
-    "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#e3e77e4ab35f1a39e4c134228b061b70043da442",
+    "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#4ea68e59bfb40385c09fd641c1192f7fdce58285",
     "module-error": "^1.0.2",
     "readable-stream": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": [
     "index.js",
     "get-sync.js",
+    "get-sync-worker.js",
     "index.d.ts",
     "CHANGELOG.md",
     "UPGRADING.md"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "index.js",
+    "get-sync.js",
     "index.d.ts",
     "CHANGELOG.md",
     "UPGRADING.md"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "UPGRADING.md"
   ],
   "dependencies": {
-    "classic-level": "^2.0.0",
+    "classic-level": "^3.0.0",
     "many-level": "git+ssh://git@github.com/ForgeVTT/many-level.git#e3e77e4ab35f1a39e4c134228b061b70043da442",
     "module-error": "^1.0.2",
     "readable-stream": "^4.0.0"

--- a/test/basic.js
+++ b/test/basic.js
@@ -20,6 +20,22 @@ test('single database', async function (t) {
   await db.close()
 })
 
+test('single database getSync', async function (t) {
+  t.plan(3)
+
+  const location = tempy.directory()
+  const db = new RaveLevel(location, { valueEncoding: 'json' })
+  const value = { number: Math.floor(Math.random() * 100000) }
+
+  await db.put('a', value)
+
+  t.is(db.supports.getSync, true)
+  t.same(db.getSync('a'), value)
+  t.is(db.getSync('missing'), undefined)
+
+  await db.close()
+})
+
 test('two databases', async function (t) {
   t.plan(3)
 
@@ -37,6 +53,26 @@ test('two databases', async function (t) {
 
   await db2.close()
   t.is(db2.status, 'closed')
+})
+
+test('follower database getSync', async function (t) {
+  t.plan(4)
+
+  const location = tempy.directory()
+  const db1 = new RaveLevel(location, { valueEncoding: 'json' })
+  const db2 = new RaveLevel(location, { valueEncoding: 'json' })
+  const value = { number: Math.floor(Math.random() * 100000) }
+
+  await db1.put('a', value)
+  await db2.open()
+
+  t.is(db2.isLeader, false)
+  t.is(db2.supports.getSync, true)
+  t.same(db2.getSync('a'), value)
+  t.is(db2.getSync('missing'), undefined)
+
+  await db1.close()
+  await db2.close()
 })
 
 test('three databases', async function (t) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -60,6 +60,7 @@ test('follower database getSync', async function (t) {
 
   const location = tempy.directory()
   const db1 = new RaveLevel(location, { valueEncoding: 'json' })
+  await db1.open()
   const db2 = new RaveLevel(location, { valueEncoding: 'json' })
   const value = { number: Math.floor(Math.random() * 100000) }
 

--- a/test/get-sync.js
+++ b/test/get-sync.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const test = require('tape')
+const tempy = require('./util/tempy')
+const { fork } = require('child_process')
+const { once } = require('events')
+const { RaveLevel } = require('..')
+
+if (process.argv[2] === 'child') {
+  (async () => {
+    const [location] = process.argv.slice(3)
+    const db = new RaveLevel(location, { valueEncoding: 'json' })
+
+    try {
+      await db.open()
+
+      process.send({
+        isLeader: db.isLeader,
+        value: db.getSync('a'),
+        missing: db.getSync('missing')
+      })
+
+      await db.close()
+      process.exit(0)
+    } catch (err) {
+      process.send({
+        error: err.message,
+        code: err.code,
+        stack: err.stack
+      })
+      process.exit(1)
+    }
+  })()
+} else {
+  test('getSync from follower process', async function (t) {
+    const location = tempy.directory()
+    const leader = new RaveLevel(location, { valueEncoding: 'json' })
+    const value = { number: Math.floor(Math.random() * 100000) }
+
+    await once(leader, 'leader')
+    await leader.put('a', value)
+
+    const result = await new Promise((resolve, reject) => {
+      const child = fork(__filename, ['child', location], { timeout: 30e3 })
+      let message = null
+
+      child.on('message', msg => {
+        message = msg
+      })
+
+      child.on('error', reject)
+
+      child.on('exit', (code, signal) => {
+        resolve({ code, signal, message })
+      })
+    })
+
+    t.is(result.code, 0)
+    t.is(result.signal, null)
+    t.is(result.message && result.message.error, undefined)
+    t.is(result.message && result.message.isLeader, false)
+    t.same(result.message && result.message.value, value)
+    t.is(result.message && result.message.missing, undefined)
+
+    await leader.close()
+  })
+}

--- a/test/get-sync.js
+++ b/test/get-sync.js
@@ -3,22 +3,41 @@
 const test = require('tape')
 const tempy = require('./util/tempy')
 const { fork } = require('child_process')
-const { once } = require('events')
 const { RaveLevel } = require('..')
+const { ClassicLevel } = require('classic-level')
 
 if (process.argv[2] === 'child') {
   (async () => {
-    const [location] = process.argv.slice(3)
+    const [mode, location] = process.argv.slice(3)
     const db = new RaveLevel(location, { valueEncoding: 'json' })
 
     try {
       await db.open()
 
-      process.send({
-        isLeader: db.isLeader,
-        value: db.getSync('a'),
-        missing: db.getSync('missing')
-      })
+      if (mode === 'blocks') {
+        let immediateRan = false
+        setImmediate(() => {
+          immediateRan = true
+        })
+
+        const value = db.getSync('a')
+        const immediateRanDuringGetSync = immediateRan
+
+        await new Promise(resolve => setImmediate(resolve))
+
+        process.send({
+          isLeader: db.isLeader,
+          value,
+          immediateRanDuringGetSync,
+          immediateRanAfterGetSync: immediateRan
+        })
+      } else {
+        process.send({
+          isLeader: db.isLeader,
+          value: db.getSync('a'),
+          missing: db.getSync('missing')
+        })
+      }
 
       await db.close()
       process.exit(0)
@@ -32,16 +51,9 @@ if (process.argv[2] === 'child') {
     }
   })()
 } else {
-  test('getSync from follower process', async function (t) {
-    const location = tempy.directory()
-    const leader = new RaveLevel(location, { valueEncoding: 'json' })
-    const value = { number: Math.floor(Math.random() * 100000) }
-
-    await once(leader, 'leader')
-    await leader.put('a', value)
-
-    const result = await new Promise((resolve, reject) => {
-      const child = fork(__filename, ['child', location], { timeout: 30e3 })
+  function spawnChild (mode, location) {
+    return new Promise((resolve, reject) => {
+      const child = fork(__filename, ['child', mode, location], { timeout: 30e3 })
       let message = null
 
       child.on('message', msg => {
@@ -54,6 +66,31 @@ if (process.argv[2] === 'child') {
         resolve({ code, signal, message })
       })
     })
+  }
+
+  async function withDelayedLeaderGets (fn) {
+    const originalGet = ClassicLevel.prototype._get
+
+    ClassicLevel.prototype._get = async function (...args) {
+      await new Promise(resolve => setTimeout(resolve, 50))
+      return originalGet.apply(this, args)
+    }
+
+    try {
+      return await fn()
+    } finally {
+      ClassicLevel.prototype._get = originalGet
+    }
+  }
+
+  test('getSync from follower process', async function (t) {
+    const location = tempy.directory()
+    const leader = new RaveLevel(location, { valueEncoding: 'json' })
+    const value = { number: Math.floor(Math.random() * 100000) }
+
+    await leader.put('a', value)
+
+    const result = await spawnChild('basic', location)
 
     t.is(result.code, 0)
     t.is(result.signal, null)
@@ -61,6 +98,28 @@ if (process.argv[2] === 'child') {
     t.is(result.message && result.message.isLeader, false)
     t.same(result.message && result.message.value, value)
     t.is(result.message && result.message.missing, undefined)
+
+    await leader.close()
+  })
+
+  test('getSync from follower process blocks the event loop', async function (t) {
+    const location = tempy.directory()
+    const leader = new RaveLevel(location, { valueEncoding: 'json' })
+    const value = { number: Math.floor(Math.random() * 100000) }
+
+    await leader.put('a', value)
+
+    const result = await withDelayedLeaderGets(() => {
+      return spawnChild('blocks', location)
+    })
+
+    t.is(result.code, 0)
+    t.is(result.signal, null)
+    t.is(result.message && result.message.error, undefined)
+    t.is(result.message && result.message.isLeader, false)
+    t.same(result.message && result.message.value, value)
+    t.is(result.message && result.message.immediateRanDuringGetSync, false)
+    t.is(result.message && result.message.immediateRanAfterGetSync, true)
 
     await leader.close()
   })


### PR DESCRIPTION
## Summary

Refactors the connection flows.
Adds `getSync()` support to rave-level on top of the new many-level opt-in hook.

Changes:

- refactors the leader connection flow to make the connect / become-leader path easier to follow
- enables `getSync` in the rave-level guest options
- adds a same-process leader registry so local follower instances can avoid deadlocking
- adds a dedicated `get-sync.js` helper for the blocking follower implementation
- implements follower `getSync()` by doing the async socket read in a worker thread, while the caller blocks with `Atomics.wait()`
- adds coverage for:
  - leader `getSync`
  - same-process follower `getSync`
  - cross-process follower `getSync`
  - missing keys
  - JSON value decoding

## Notes

This PR depends on the many-level PR that adds opt-in `getSync` support. Before merge, the many-level dependency hash should be updated to the merged many-level commit.

Follower `getSync({ snapshot })` is explicitly rejected with `LEVEL_NOT_SUPPORTED`. Supporting that correctly would require a broader distributed snapshot identity / lifetime model, which is intentionally out of scope here.

Related PR: https://github.com/ForgeVTT/many-level/pull/3